### PR TITLE
Fix 1.0.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Version 1.0.6
 
-* remove lazy load, fixing a race with fork() [felixbuenemann]
+* remove lazy load, fixing a race with multi-threading [felixbuenemann]
 * make `Image#to_a` much faster [John Cupitt]
 * remove the `at_exit` handler [John Cupitt]
 


### PR DESCRIPTION
The problems fixed by removing lazy-loading of GI are related to running init in multiple threads concurrently, not in multiple processes.