### PR TITLE
Add a stub for bundler auto require

### DIFF
--- a/lib/ruby-vips.rb
+++ b/lib/ruby-vips.rb
@@ -1,0 +1,1 @@
+require 'vips'


### PR DESCRIPTION
Because the gem is named "ruby-vips" bundler will try to require a file called "lib/ruby-vips.rb" instead of "lib/vips.rb".

This PR adds a stub file so that auto-require works as expected.

This means the gem can now be included in the Gemfile using a simple:

```ruby
gem 'ruby-vips'
```

Instead of:

```ruby
gem 'ruby-vips', require: 'vips'
```