### PR TITLE
trailing 'and' seems to be a bug

### DIFF
--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -1348,10 +1348,10 @@ module Vips
                 end
 
                 # MODIFY INPUT args count as OUTPUT as well
-                if (arg_flags & ARGUMENT_OUTPUT) != 0 or
-                    ((arg_flags & ARGUMENT_INPUT) != 0 and
+                if (arg_flags & ARGUMENT_OUTPUT) != 0 ||
+                    ((arg_flags & ARGUMENT_INPUT) != 0 &&
                      (arg_flags & ARGUMENT_MODIFY) != 0)
-                    if (arg_flags & ARGUMENT_REQUIRED) != 0 and
+                    if (arg_flags & ARGUMENT_REQUIRED) != 0
                         required_output << value
                     else
                         optional_output << value


### PR DESCRIPTION
Because of trailing the `required_output << value` was a part of condition. It is a miracle that this code worked.
When the `(arg_flags & ARGUMENT_REQUIRED) != 0` was true the `required_output << value` was executed returning the object that worked as `true` for `if` but the true-branch was empty. When it was false it ignored the `required_output << value` action thanks to the fact the `and` is not actually the same as `&&`. If it was `&&` the second operand would be calculated.

The `and` and `or` operators are of very low precedence and actually work as `if` and `else` because "everything is an object in Ruby". But the same Ruby fact made you miss the typo. Their operands don't get always calculated unlike operands of `||` and `&&` do. But I see them everywhere in your code and I suppose you want them to actually be `||` and `&&`. I recommend to carefully replace them everywhere.