### PR TITLE
Fix segmentation fault in Image.new_from_buffer with UTF-8 buffer

### DIFF
--- a/lib/vips/gvalue.rb
+++ b/lib/vips/gvalue.rb
@@ -137,7 +137,7 @@ module GObject
                 value.each {|image| ::GObject::g_object_ref image}
 
             when Vips::BLOB_TYPE
-                len = value.length
+                len = value.bytesize
                 ptr = GLib::g_malloc len
                 Vips::vips_value_set_blob self, GLib::G_FREE, ptr, len
                 ptr.write_bytes value

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -279,7 +279,7 @@ module Vips
         # @macro vips.loadopts
         # @return [Image] the loaded image
         def self.new_from_buffer data, option_string, opts = {}
-            loader = Vips::vips_foreign_find_load_buffer data, data.length
+            loader = Vips::vips_foreign_find_load_buffer data, data.bytesize
             raise Vips::Error if loader == nil
 
             Vips::Operation.call loader, [data], opts, option_string


### PR DESCRIPTION
When string is in a binary encoding, then `String#length` always equals `String#bytesize`. However, in other encodings like UTF-8 `String#length` will be lower than `String#bytesize` if the string contains printable multibyte characters (which will always happen with binary files like
images).

If we call Image.new_from_buffer with content of a binary file like an image in UTF-8 encoding, it will raise a segmentation fault. This is because it's communicating the buffer size to libvips incorrectly, due
to using `String#length`. We fix that by switching to `String#bytesize`.