### PR TITLE
Remove duplicate function attach

### DIFF
--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -16,7 +16,6 @@ module Vips
 
     attach_function :vips_filename_get_filename, [:string], :string
     attach_function :vips_filename_get_options, [:string], :string
-    attach_function :vips_filename_get_options, [:string], :string
 
     attach_function :vips_foreign_find_load, [:string], :string
     attach_function :vips_foreign_find_save, [:string], :string


### PR DESCRIPTION
The `attach_function :vips_filename_get_options` statement is repeated, which was probably not intended.