### PR TITLE
Fix NotFountError when using libvips older than 8.5

### DIFF
--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -39,7 +39,9 @@ module Vips
     if Vips::at_least_libvips?(8, 6)
         attach_function :vips_addalpha, [:pointer, :pointer, :varargs], :int
     end
-    attach_function :vips_image_hasalpha, [:pointer], :int
+    if Vips::at_least_libvips?(8, 5)
+        attach_function :vips_image_hasalpha, [:pointer], :int
+    end
 
     attach_function :vips_image_set,
         [:pointer, :string, GObject::GValue.ptr], :void
@@ -702,11 +704,13 @@ module Vips
             [width, height]
         end
 
-        # Detect if image has an alpha channel
-        #
-        # @return [Boolean] true if image has an alpha channel.
-        def has_alpha?
-            return Vips::vips_image_hasalpha(self) != 0
+        if Vips::at_least_libvips?(8, 5)
+            # Detect if image has an alpha channel
+            #
+            # @return [Boolean] true if image has an alpha channel.
+            def has_alpha?
+                return Vips::vips_image_hasalpha(self) != 0
+            end
         end
 
         # vips_addalpha was added in libvips 8.6


### PR DESCRIPTION
I'm using Ubuntu-16.04 with
```
Vips::LIBRARY_VERSION # => "8.2.2-Sat Jan 30 17:12:08 UTC 2016" 
```
It fails with
```
FFI::NotFoundError (Function 'vips_image_hasalpha' not found in [libvips.so])
```
This function was [added in libvips-8.5.0](https://github.com/jcupitt/libvips/blob/master/ChangeLog#L158). Attached PR fixes this by checking the version.