### PR TITLE
Allow Operation options to have nil values

### DIFF
--- a/lib/vips/operation.rb
+++ b/lib/vips/operation.rb
@@ -316,6 +316,8 @@ module Vips
 
             # set all optional inputs
             optional.each do |key, value|
+                next if value.nil?
+
                 arg_name = key.to_s
 
                 if optional_input.has_key? arg_name

--- a/spec/vips_spec.rb
+++ b/spec/vips_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Vips do
             expect(image.bands).to eq(12)
         end
 
+        it 'ignores optional arguments with nil values' do
+            image = Vips::Operation.call "black", [200, 200], { bands: nil }
+
+            expect(image.width).to eq(200)
+            expect(image.height).to eq(200)
+            expect(image.bands).to eq(1)
+        end
+
         it 'can handle enum arguments' do
             black = Vips::Operation.call "black", [200, 200]
             embed = Vips::Operation.call "embed", [black, 10, 10, 500, 500], 


### PR DESCRIPTION
When you're passing an optional argument, sometimes it's convenient to be able to pass nil, and expect the same behaviour as if you didn't pass the option at all (have libvips use the default value).

```rb
image.embed(background: nil)
```

Currently a type mismatch exception is raised if nil is passed for an Operation option value. So in my ImageProcessing gem I have to work around this by excluding the parameter if it's nil (e.g. [here](https://github.com/janko-m/image_processing/blob/v1.3.0/lib/image_processing/vips.rb#L45)).

This commit modifies resolving arguments in a way that options with nil values are skipped and not forwarded to libvips.