### PR TITLE
Use correct syntax for symbols with dashes in them

### DIFF
--- a/lib/vips/compass_direction.rb
+++ b/lib/vips/compass_direction.rb
@@ -7,10 +7,10 @@ module Vips
     # * `:east`
     # * `:south`
     # * `:west`
-    # * `:north-east`
-    # * `"south-east`
-    # * `:south-west`
-    # * `:north-west`
+    # * `:"north-east"`
+    # * `:"south-east"`
+    # * `:"south-west"`
+    # * `:"north-west"`
 
     class CompassDirection < Symbol
     end


### PR DESCRIPTION
Since Ruby cannot generate symbols with dashes in them using just the `:<value>` syntax, I thought it would be nice for the docs to show the correct way of generating these symbols.