### PR TITLE
Fix Image#composite docs

### DIFF
--- a/lib/vips/blend_mode.rb
+++ b/lib/vips/blend_mode.rb
@@ -1,0 +1,34 @@
+module Vips
+
+    # Blend mode to use when compositing images. See {Image#composite}.
+    #
+    # `:clear` – where the second object is drawn, the first is removed
+    # `:source` – the second object is drawn as if nothing were below
+    # `:over` – the image shows what you would expect if you held two semi-transparent slides on top of each other
+    # `:in` – the first object is removed completely, the second is only drawn where the first was
+    # `:out` – the second is drawn only where the first isn't
+    # `:atop` – this leaves the first object mostly intact, but mixes both objects in the overlapping area
+    # `:dest` – leaves the first object untouched, the second is discarded completely
+    # `:dest_over` – like `:over`, but swaps the arguments
+    # `:dest_in` – like `:in`, but swaps the arguments
+    # `:dest_out` – like `:out`, but swaps the arguments
+    # `:dest_atop` – like `:atop`, but swaps the arguments
+    # `:xor` – something like a difference operator
+    # `:add` – a bit like adding the two images
+    # `:saturate` – a bit like the darker of the two
+    # `:multiply` – at least as dark as the darker of the two inputs
+    # `:screen` – at least as light as the lighter of the inputs
+    # `:overlay` – multiplies or screens colors, depending on the lightness
+    # `:darken` – the darker of each component
+    # `:lighten` – the lighter of each component
+    # `:colour_dodge` – brighten first by a factor second
+    # `:colour_burn` – darken first by a factor of second
+    # `:hard_light` – multiply or screen, depending on lightness
+    # `:soft_light` – darken or lighten, depending on lightness
+    # `:difference` – difference of the two
+    # `:exclusion` – somewhat like `:difference`, but lower-contrast
+
+    class BlendMode < Symbol
+    end
+end
+

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -1047,7 +1047,7 @@ module Vips
         # Composite a set of images with a set of blend modes.
         #
         # @param other [Image, Array<Image>] images to composite
-        # @param mode [Symbol, Array<Symbol>] blend modes to use
+        # @param mode [BlendMode, Array<BlendMode>] blend modes to use
         # @return [Image] blended image
         def composite other, mode, opts = {}
             unless other.is_a? Array

--- a/lib/vips/image.rb
+++ b/lib/vips/image.rb
@@ -1046,8 +1046,9 @@ module Vips
 
         # Composite a set of images with a set of blend modes.
         #
-        # @param other [Image, Array<Image>, Real, Array<Real>] bands to append
-        # @return [Image] many band image
+        # @param other [Image, Array<Image>] images to composite
+        # @param mode [Symbol, Array<Symbol>] blend modes to use
+        # @return [Image] blended image
         def composite other, mode, opts = {}
             unless other.is_a? Array
                 other = [other]


### PR DESCRIPTION
The `Vips::Image#composite` docs weren't accurate, because the `other` can only be `Image` or `Array<Image>`. I think it might be a leftover from a copy-paste of the `Vips::Image#bandjoin` docs above.

Additionally, I also added `Vips::BlendMode` to document the possible values for `mode` (copy-pasted from `VipsBlendMode` libvips docs). I added that change as a separate commit, so you can take just the first one if you would prefer :)